### PR TITLE
Added support for test groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Selenium-Maven-Template
 =======================
 
-A maven template for Selenium that has the latest dependencies so that you can just check out and start writing tests in five easy steps.
+A maven template for Selenium that has the latest dependencies so that you can just check out and start writing tests in four easy steps.
 
 
 1. Open a terminal window/command prompt
@@ -42,5 +42,9 @@ You can specify a grid to connect to where you can choose your browser, browser 
 You can even specify multiple threads (you can do it on a grid as well!):
 
 - -Dthreads=2
+
+You can execute one or more specific groups of tests:
+
+- -Dgroups=checkintest,functest
 
 If the tests fail screenshots will be saved in ${project.basedir}/target/screenshots

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <seleniumGridURL/>
         <platform/>
         <browserVersion/>
+        <groups />
     </properties>
 
     <dependencies>
@@ -148,6 +149,7 @@
                             <includes>
                                 <include>**/*WebDriver.java</include>
                             </includes>
+                            <groups>${groups}</groups>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/test/java/com/lazerycode/selenium/DriverFactory.java
+++ b/src/test/java/com/lazerycode/selenium/DriverFactory.java
@@ -20,7 +20,7 @@ public class DriverFactory {
     private static List<WebDriver> webDriverPool = Collections.synchronizedList(new ArrayList<WebDriver>());
     private static ThreadLocal<WebDriver> driverThread;
 
-    @BeforeSuite
+    @BeforeSuite(alwaysRun = true)
     public static void instantiateDriverObject() {
 
         final DriverType desiredDriver = determineEffectiveDriverType(System.getProperty("browser"));
@@ -39,12 +39,12 @@ public class DriverFactory {
         return driverThread.get();
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun = true)
     public static void clearCookies() {
         getDriver().manage().deleteAllCookies();
     }
 
-    @AfterSuite
+    @AfterSuite(alwaysRun = true)
     public static void closeDriverObject() {
         for (WebDriver driver : webDriverPool) {
             driver.quit();


### PR DESCRIPTION
Specified groups of tests can now be executed using the groups command line parameter.

For example the tests with annotation:

``` java
@Test(groups = { "functest" })
```

can be executed by specifying the following parameter:

```
-Dgroups=functest
```

If this parameter is not specified all tests will be executed.
