### PR TITLE
rm remote-driver as it comes with selenium-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-remote-driver</artifactId>
-            <version>${selenium.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.codeborne</groupId>
             <artifactId>phantomjsdriver</artifactId>
             <version>1.3.0</version>


### PR DESCRIPTION
the remote driver comes with selenium-java in the correct version. No need to define it or am I missing something?