### PR TITLE
Update RepositoryMap.xml

### DIFF
--- a/src/test/resources/RepositoryMap.xml
+++ b/src/test/resources/RepositoryMap.xml
@@ -25,10 +25,10 @@
             </version>
         </driver>
         <driver id="googlechrome">
-            <version id="2.33">
+            <version id="2.36">
                 <bitrate thirtytwobit="true" sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/2.33/chromedriver_win32.zip</filelocation>
-                    <hash>b52ca785707eade99c56309ce9d66c1177b5d4a9</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/2.36/chromedriver_win32.zip</filelocation>
+                    <hash>c6ee81e69825a740c4de6978373e55dc3fd29b9e</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>


### PR DESCRIPTION
changing values on input fields in Chrome 65+ does not work with the old driver. 
https://stackoverflow.com/questions/11549647/getting-the-url-of-the-current-page-using-selenium-webdriver