### PR TITLE
Trying to resolve an issue with using this template with JDK11 and 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ target
 \.settings
 \.dorsync
 /nbactions.xml
+\.github
 
 # Binary Downloads #
 ####################

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM maven:3.6.3-jdk-13
+MAINTAINER Aditya Inapurapu adityaii@gmail.com
+RUN mkdir -p /usr/src/app
+EXPOSE 8080
+WORKDIR /usr/src/app
+ADD . /usr/src/app
+RUN mvn clean test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM maven:3.6.3-jdk-13
-MAINTAINER Aditya Inapurapu adityaii@gmail.com
-RUN mkdir -p /usr/src/app
-EXPOSE 8080
-WORKDIR /usr/src/app
-ADD . /usr/src/app
-RUN mvn clean test

--- a/Dockerfile_jdk11
+++ b/Dockerfile_jdk11
@@ -1,0 +1,7 @@
+FROM maven:3.6.3-jdk-11
+MAINTAINER Aditya Inapurapu adityaii@gmail.com
+RUN mkdir -p /usr/src/app
+EXPOSE 8080
+WORKDIR /usr/src/app
+ADD . /usr/src/app
+RUN mvn clean test

--- a/Dockerfile_jdk13
+++ b/Dockerfile_jdk13
@@ -1,0 +1,7 @@
+FROM maven:3.6.3-jdk-13
+MAINTAINER Aditya Inapurapu adityaii@gmail.com
+RUN mkdir -p /usr/src/app
+EXPOSE 8080
+WORKDIR /usr/src/app
+ADD . /usr/src/app
+RUN mvn clean test

--- a/Dockerfile_jdk8
+++ b/Dockerfile_jdk8
@@ -1,0 +1,7 @@
+FROM maven:3.6.3-jdk-8
+MAINTAINER Aditya Inapurapu adityaii@gmail.com
+RUN mkdir -p /usr/src/app
+EXPOSE 8080
+WORKDIR /usr/src/app
+ADD . /usr/src/app
+RUN mvn clean test

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All dependencies should now be downloaded and the example google cheese test wil
 - The maven failsafe plugin has been used to create a profile with the id "selenium-tests".  This is active by default, but if you want to perform a build without running your selenium tests you can disable it using:
 
         mvn clean verify -P-selenium-tests
-        
+
 - The maven-failsafe-plugin will pick up any files that end in IT by default.  You can customise this is you would prefer to use a custom identifier for your Selenium tests.
 
 ### Known problems...
@@ -45,10 +45,10 @@ Not got PhantomJS?  Don't worry that will be automatically downloaded for you as
 
 You can specify a grid to connect to where you can choose your browser, browser version and platform:
 
-- -Dremote=true 
-- -DseleniumGridURL=http://{username}:{accessKey}@ondemand.saucelabs.com:80/wd/hub 
-- -Dplatform=xp 
-- -Dbrowser=firefox 
+- -Dremote=true
+- -DseleniumGridURL=http://{username}:{accessKey}@ondemand.saucelabs.com:80/wd/hub
+- -Dplatform=xp
+- -Dbrowser=firefox
 - -DbrowserVersion=44
 
 You can even specify multiple threads (you can do it on a grid as well!):
@@ -73,3 +73,16 @@ You have probably got outdated driver binaries, by default they are not overwrit
 
 - `mvn clean verify -Doverwrite.binaries=true`
 - Delete the `selenium_standalone_binaries` folder in your resources directory
+
+### Build docker image from Dockerfile
+
+Note: When using JDK 11 or 13, a javax.xml.bind.JAXBException is occuring and compile time because of certain Java EE binaries that have been removed from JDK9+.
+
+#### Image with JDK13
+```docker build -t selenium-maven-template:jdk13 --file Dockerfile_jdk13 .```
+
+#### Image with JDK11
+```docker build -t selenium-maven-template:jdk11 --file Dockerfile_jdk11 .```
+
+#### Image with JDK8
+```docker build -t selenium-maven-template:jdk8 --file Dockerfile_jdk8 .```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You have probably got outdated driver binaries, by default they are not overwrit
 
 ### Build docker image from Dockerfile
 
-Note: When using JDK 11 or 13, a javax.xml.bind.JAXBException is occuring and compile time because of certain Java EE binaries that have been removed from JDK9+.
+Note: When using JDK 11 or 13, a javax.xml.bind.JAXBException is occuring at compile time because of certain Java EE binaries that have been removed from JDK9+. This is a known issue. Please continue building with JDK8 till the issue is resolved for other JDKs.
 
 #### Image with JDK13
 ```docker build -t selenium-maven-template:jdk13 --file Dockerfile_jdk13 .```

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <phantomjsdriver.version>1.4.1</phantomjsdriver.version>
         <testng.version>6.11</testng.version>
         <!--Plugin Versions-->
-        <driver-binary-downloader-maven-plugin.version>1.0.11</driver-binary-downloader-maven-plugin.version>
+        <driver-binary-downloader-maven-plugin.version>1.0.12</driver-binary-downloader-maven-plugin.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
         <!--Configuration Properties-->

--- a/pom.xml
+++ b/pom.xml
@@ -74,13 +74,8 @@
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <version>2.2.11</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+            <version>2.1</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
             <version>${hamcrest-all.version}</version>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-remote-driver</artifactId>
             <version>${selenium.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,9 @@
         <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
         <!--Configuration Properties-->
         <overwrite.binaries>false</overwrite.binaries>
+        <read.timeout>30000</read.timeout>
+        <connection.timeout>40000</connection.timeout>
+        <retry.attempts>4</retry.attempts>
         <browser>firefox</browser>
         <threads>1</threads>
         <remote>false</remote>
@@ -134,9 +137,9 @@
                             <customRepositoryMap>${project.basedir}/src/test/resources/RepositoryMap.xml</customRepositoryMap>
                             <overwriteFilesThatExist>${overwrite.binaries}</overwriteFilesThatExist>
                             <onlyGetDriversForHostOperatingSystem>false</onlyGetDriversForHostOperatingSystem>
-                            <fileDownloadRetryAttempts>4</fileDownloadRetryAttempts>
-                            <fileDownloadConnectionTimeout>40000</fileDownloadConnectionTimeout>
-                            <fileDownloadReadTimeout>30000</fileDownloadReadTimeout>
+                            <fileDownloadRetryAttempts>${retry.attempts}</fileDownloadRetryAttempts>
+                            <fileDownloadConnectionTimeout>${connection.timeout}</fileDownloadConnectionTimeout>
+                            <fileDownloadReadTimeout>${read.timeout}</fileDownloadReadTimeout>
                             <operatingSystems>
                                 <windows>true</windows>
                                 <linux>true</linux>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,9 @@
                             <customRepositoryMap>${project.basedir}/src/test/resources/RepositoryMap.xml</customRepositoryMap>
                             <overwriteFilesThatExist>${overwrite.binaries}</overwriteFilesThatExist>
                             <onlyGetDriversForHostOperatingSystem>false</onlyGetDriversForHostOperatingSystem>
+                            <fileDownloadRetryAttempts>4</fileDownloadRetryAttempts>
+                            <fileDownloadConnectionTimeout>40000</fileDownloadConnectionTimeout>
+                            <fileDownloadReadTimeout>30000</fileDownloadReadTimeout>
                             <operatingSystems>
                                 <windows>true</windows>
                                 <linux>true</linux>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.3.1</version>
         </dependency>


### PR DESCRIPTION
I use this template quite often and recently, when I switched to JDK11, I observed that the compilation itself is failing with a javax.xml.bind.JAXBException. I switched back to JDK8 to continue with my work, but I'd like to resolve this JAXBException issue on JDK11 and 13. 

Apparently, some JAVA EE libraries have been removed from JDK9+ and javax.xml.bind is one of them. I haven't been able to resolve the issue yet, even though there are many suggestions on stackoverflow regarding the same problem. None of those suggested solutions worked for me. 

I created Dockerfiles for each JDK. That way, whenever we have a potential fix, we can test on 3 JDKs at the same time by running the build as individual docker image builds. 

I added brief details in the README.md as well. Please help me fix this issue.

